### PR TITLE
Added a Jupyter notebook for nuclei segmentation using scikit-image.

### DIFF
--- a/notebooks/nuclei_segmentation.ipynb
+++ b/notebooks/nuclei_segmentation.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Nuclei Segmentation in Microscopy Images\n",
+    "\n",
+    "In this notebook, we will segment and count cell nuclei in a fluorescence microscopy image using **scikit-image**. The data file is located in the `data` folder."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load and Display the Image\n",
+    "\n",
+    "Let's begin by loading the image and displaying it to understand what it looks like."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from skimage import io\n",
+    "\n",
+    "# Load the image\n",
+    "image_path = \"../data/hela-cells-8bit.jpg\"\n",
+    "image = io.imread(image_path)\n",
+    "\n",
+    "# Display the image\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.title('Original Image')\n",
+    "plt.imshow(image)\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extract the Blue Channel\n",
+    "\n",
+    "To segment the nuclei, we first extract the blue channel, assuming it is the DAPI stain that marks the nuclei."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Extract the blue channel\n",
+    "blue_channel = image[..., 2]\n",
+    "\n",
+    "# Display the blue channel\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.title('Blue Channel')\n",
+    "plt.imshow(blue_channel, cmap='gray')\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Apply Gaussian Blur\n",
+    "\n",
+    "Next, we will apply a Gaussian blur to reduce noise in the image, which will help in better segmentation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from skimage import filters\n",
+    "\n",
+    "# Apply Gaussian blur\n",
+    "blurred_image = filters.gaussian(blue_channel, sigma=1)\n",
+    "\n",
+    "# Display the blurred image\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.title('Blurred Image')\n",
+    "plt.imshow(blurred_image, cmap='gray')\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Threshold the Image\n",
+    "\n",
+    "Now we will use Otsu's method to threshold the image and create a binary representation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Apply Otsu's thresholding\n",
+    "thresh = filters.threshold_otsu(blurred_image)\n",
+    "binary_image = blurred_image > thresh\n",
+    "\n",
+    "# Display the binary image\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.title('Binary Image')\n",
+    "plt.imshow(binary_image, cmap='gray')\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Remove Small Objects\n",
+    "\n",
+    "To clean up the binary image, we will remove small objects that are unlikely to be nuclei."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from skimage import morphology\n",
+    "\n",
+    "# Remove small objects\n",
+    "cleaned_image = morphology.remove_small_objects(binary_image, min_size=50)\n",
+    "\n",
+    "# Display the cleaned image\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.title('Cleaned Image')\n",
+    "plt.imshow(cleaned_image, cmap='gray')\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Label and Count Nuclei\n",
+    "\n",
+    "Finally, we will label each connected component in the cleaned binary image and count the number of unique components, which corresponds to the number of nuclei."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from skimage import measure, color\n",
+    "\n",
+    "# Label connected components\n",
+    "labeled_image = measure.label(cleaned_image)\n",
+    "nuclei_count = labeled_image.max()\n",
+    "print(f'Number of nuclei: {nuclei_count}')\n",
+    "\n",
+    "# Display labeled image\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.title('Labeled Nuclei')\n",
+    "plt.imshow(color.label2rgb(labeled_image, image=image, bg_label=0))\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercise\n",
+    "\n",
+    "Try altering the `min_size` parameter in the `remove_small_objects` function to see how it affects the nuclei count. What happens if you set it too high or too low?"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.3.0, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

Implemented a solution to issue #1 by creating a new Jupyter notebook in the "notebooks" directory that segments and counts nuclei in a provided fluorescence microscopy image using the scikit-image library. The notebook is structured with markdown explanations and separate code cells, performing tasks such as loading the image, extracting the blue channel, applying Gaussian blur, thresholding with Otsu's method, removing small objects, and labeling to count nuclei. Displayed images at each step to facilitate understanding.

closes #1