### PR TITLE
Added `rgb2gray` to ensure consistent image preprocessing in segmentation workflow.

### DIFF
--- a/notebooks/segmentation_analysis.ipynb
+++ b/notebooks/segmentation_analysis.ipynb
@@ -56,6 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from skimage.color import rgb2gray\n",
     "if len(image.shape) == 3:\n",
     "    image_gray = rgb2gray(image)\n",
     "else:\n",


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.3.2, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

Enhanced the Jupyter notebook for cell segmentation by importing `rgb2gray` from the `skimage.color` module. This addition ensures that if the input image has three dimensions (indicative of an RGB image), it is converted to grayscale for consistent processing, thereby enhancing the robustness of the segmentation workflow. 

During solving this task, the following errors occurred:

* <details>
    <summary>Error during {'action': 'create', 'filename': 'notebooks/segmentation_analysis.ipynb'}: Error during notebook execution.</summary>
    <pre>    Traceback (most recent call last):
      File "C:\structure\code\git-bob\src\git_bob\_utilities.py", line 332, in execute_notebook
        ep.preprocess(notebook, {'metadata': {'path': './'}})
      File "C:\Users\rober\miniforge3\envs\devbio-napari-env\Lib\site-packages\nbconvert\preprocessors\execute.py", line 103, in preprocess
        self.preprocess_cell(cell, resources, index)
      File "C:\Users\rober\miniforge3\envs\devbio-napari-env\Lib\site-packages\nbconvert\preprocessors\execute.py", line 124, in preprocess_cell
        cell = self.execute_cell(cell, index, store_history=True)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\rober\miniforge3\envs\devbio-napari-env\Lib\site-packages\jupyter_core\utils\__init__.py", line 165, in wrapped
        return loop.run_until_complete(inner)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\rober\miniforge3\envs\devbio-napari-env\Lib\asyncio\base_events.py", line 654, in run_until_complete
        return future.result()
               ^^^^^^^^^^^^^^^
      File "C:\Users\rober\miniforge3\envs\devbio-napari-env\Lib\site-packages\nbclient\client.py", line 1062, in async_execute_cell
        await self._check_raise_for_error(cell, cell_index, exec_reply)
      File "C:\Users\rober\miniforge3\envs\devbio-napari-env\Lib\site-packages\nbclient\client.py", line 918, in _check_raise_for_error
        raise CellExecutionError.from_cell_and_msg(cell, exec_reply_content)
    nbclient.exceptions.CellExecutionError: An error occurred while executing the following cell:
    ------------------
    distance = ndi.distance_transform_edt(image_tophat)
    local_maxi = feature.peak_local_max(distance, indices=False, min_distance=5)
    markers = ndi.label(local_maxi)[0]
    ------------------
    
    
    [1;31m---------------------------------------------------------------------------[0m
    [1;31mTypeError[0m                                 Traceback (most recent call last)
    Cell [1;32mIn[6], line 2[0m
    [0;32m      1[0m distance [38;5;241m=[39m ndi[38;5;241m.[39mdistance_transform_edt(image_tophat)
    [1;32m----> 2[0m local_maxi [38;5;241m=[39m [43mfeature[49m[38;5;241;43m.[39;49m[43mpeak_local_max[49m[43m([49m[43mdistance[49m[43m,[49m[43m [49m[43mindices[49m[38;5;241;43m=[39;49m[38;5;28;43;01mFalse[39;49;00m[43m,[49m[43m [49m[43mmin_distance[49m[38;5;241;43m=[39;49m[38;5;241;43m5[39;49m[43m)[49m
    [0;32m      3[0m markers [38;5;241m=[39m ndi[38;5;241m.[39mlabel(local_maxi)[[38;5;241m0[39m]
    
    [1;31mTypeError[0m: peak_local_max() got an unexpected keyword argument 'indices'
    
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "C:\structure\code\git-bob\src\git_bob\_ai_github_utilities.py", line 382, in solve_github_issue
        message = filename + ":" + create_or_modify_file(repository, issue, filename, branch_name, discussion,
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\structure\code\git-bob\src\git_bob\_ai_github_utilities.py", line 297, in create_or_modify_file
        execute_notebook_in_repository(repository, branch_name, filename)
      File "C:\structure\code\git-bob\src\git_bob\_github_utilities.py", line 744, in execute_notebook_in_repository
        new_notebook_content = execute_notebook(notebook_content)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\structure\code\git-bob\src\git_bob\_utilities.py", line 334, in execute_notebook
        raise Exception("Error during notebook execution.")
    Exception: Error during notebook execution.
    </pre>
</details>
            
* <details>
    <summary>Error during {'action': 'download', 'source_url': '...', 'target_filename': 'notebooks/segmentation_analysis.ipynb'}: Can only download from GitHub URLs.</summary>
    <pre>    Traceback (most recent call last):
      File "C:\structure\code\git-bob\src\git_bob\_ai_github_utilities.py", line 393, in solve_github_issue
        download_to_repository(repository, branch_name, source_url, target_filename)
      File "C:\structure\code\git-bob\src\git_bob\_github_utilities.py", line 803, in download_to_repository
        raise Exception("Can only download from GitHub URLs.")
    Exception: Can only download from GitHub URLs.
    </pre>
</details>
            
* <details>
    <summary>Error during {'action': 'execute', 'filename': 'notebooks/segmentation_analysis.ipynb'}: [WinError 2] The system cannot find the file specified: './notebooks'</summary>
    <pre>    Traceback (most recent call last):
      File "C:\structure\code\git-bob\src\git_bob\_ai_github_utilities.py", line 412, in solve_github_issue
        execute_notebook_in_repository(repository, branch_name, filename)
      File "C:\structure\code\git-bob\src\git_bob\_github_utilities.py", line 734, in execute_notebook_in_repository
        os.chdir("./" + path_without_filename)
    FileNotFoundError: [WinError 2] The system cannot find the file specified: './notebooks'
    </pre>
</details>
            


closes #19