### PR TITLE
Fix shape mismatch error in segmentation by correcting mask parameter.

### DIFF
--- a/notebooks/segmentation_analysis.ipynb
+++ b/notebooks/segmentation_analysis.ipynb
@@ -143,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "labeled_image = segmentation.watershed(gradient, markers, mask=image_gray)\n",
+    "labeled_image = segmentation.watershed(gradient, markers, mask=image_tophat)\n",
     "plt.imshow(color.label2rgb(labeled_image, image=image, bg_label=0), cmap='nipy_spectral')\n",
     "plt.title('Segmented Cells')\n",
     "plt.axis('off')\n",


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.3.2, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

In response to issue #33, enhancements were made to the segmentation workflow in the Jupyter notebook by replacing the incorrect mask parameter in the `segmentation.watershed` function. The mask was originally set to `image_gray`, causing a shape mismatch error, and has been corrected to `image_tophat` to ensure the proper execution of the notebook for cell segmentation. 

During solving this task, the following errors occurred:

* <details>
    <summary>Error during {'action': 'modify', 'filename': 'notebooks/segmentation_analysis.ipynb'}: 409 {"message": "notebooks/segmentation_analysis.ipynb does not match e8214a957991fc35336ca6918d76ba221398fb2f", "documentation_url": "https://docs.github.com/rest/repos/contents#create-or-update-file-contents", "status": "409"}</summary>
    <pre>    Traceback (most recent call last):
      File "C:\structure\code\git-bob\src\git_bob\_ai_github_utilities.py", line 392, in solve_github_issue
        message = filename + ":" + create_or_modify_file(repository, issue, filename, branch_name, discussion,
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\structure\code\git-bob\src\git_bob\_ai_github_utilities.py", line 298, in create_or_modify_file
        execute_notebook_in_repository(repository, branch_name, filename)
      File "C:\structure\code\git-bob\src\git_bob\_github_utilities.py", line 753, in execute_notebook_in_repository
        repo.update_file(file_path, commit_message, new_notebook_content, file.sha, branch=branch_name)
      File "C:\Users\rober\miniforge3\envs\devbio-napari-env\Lib\site-packages\github\Repository.py", line 2541, in update_file
        headers, data = self._requester.requestJsonAndCheck(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\rober\miniforge3\envs\devbio-napari-env\Lib\site-packages\github\Requester.py", line 550, in requestJsonAndCheck
        return self.__check(*self.requestJson(verb, url, parameters, headers, input, self.__customConnection(url)))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\rober\miniforge3\envs\devbio-napari-env\Lib\site-packages\github\Requester.py", line 611, in __check
        raise self.createException(status, responseHeaders, data)
    github.GithubException.GithubException: 409 {"message": "notebooks/segmentation_analysis.ipynb does not match e8214a957991fc35336ca6918d76ba221398fb2f", "documentation_url": "https://docs.github.com/rest/repos/contents#create-or-update-file-contents", "status": "409"}
    </pre>
</details>
            


closes #33